### PR TITLE
Expose template content as `raw_text`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -15,6 +15,8 @@ const TypeScript = require("tree-sitter-typescript/typescript/grammar");
 module.exports = grammar(TypeScript, {
   name: "glimmer_typescript",
 
+  externals: ($, previous) => previous.concat([$.raw_text]),
+
   rules: {
     /**
      * TODO: add support for attributes
@@ -27,18 +29,10 @@ module.exports = grammar(TypeScript, {
      *         https://github.com/emberjs/rfcs/
      */
     glimmer_template: ($) =>
-      choice(
-        seq(
-          field("open_tag", $.glimmer_opening_tag),
-          field("content", repeat($._glimmer_template_content)),
-          field("close_tag", $.glimmer_closing_tag),
-        ),
-        // empty template has no content
-        // <template></template>
-        seq(
-          field("open_tag", $.glimmer_opening_tag),
-          field("close_tag", $.glimmer_closing_tag),
-        ),
+      seq(
+        field("open_tag", $.glimmer_opening_tag),
+        optional(alias(repeat($._glimmer_template_content), $.raw_text)),
+        field("close_tag", $.glimmer_closing_tag),
       ),
 
     _glimmer_template_content: (_) => /.{1,}/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2753,60 +2753,43 @@
       ]
     },
     "glimmer_template": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "FIELD",
+          "name": "open_tag",
+          "content": {
+            "type": "SYMBOL",
+            "name": "glimmer_opening_tag"
+          }
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "open_tag",
-              "content": {
-                "type": "SYMBOL",
-                "name": "glimmer_opening_tag"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "content",
+              "type": "ALIAS",
               "content": {
                 "type": "REPEAT",
                 "content": {
                   "type": "SYMBOL",
                   "name": "_glimmer_template_content"
                 }
-              }
+              },
+              "named": true,
+              "value": "raw_text"
             },
             {
-              "type": "FIELD",
-              "name": "close_tag",
-              "content": {
-                "type": "SYMBOL",
-                "name": "glimmer_closing_tag"
-              }
+              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "open_tag",
-              "content": {
-                "type": "SYMBOL",
-                "name": "glimmer_opening_tag"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "close_tag",
-              "content": {
-                "type": "SYMBOL",
-                "name": "glimmer_closing_tag"
-              }
-            }
-          ]
+          "type": "FIELD",
+          "name": "close_tag",
+          "content": {
+            "type": "SYMBOL",
+            "name": "glimmer_closing_tag"
+          }
         }
       ]
     },
@@ -12026,6 +12009,10 @@
     {
       "type": "SYMBOL",
       "name": "__error_recovery"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "raw_text"
     }
   ],
   "inline": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2751,6 +2751,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "raw_text",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -4365,6 +4375,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "raw_text",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "readonly_type",

--- a/test/corpus/glimmer.txt
+++ b/test/corpus/glimmer.txt
@@ -14,6 +14,7 @@ const Named = <template>
       (identifier)
       (glimmer_template
         (glimmer_opening_tag)
+        (raw_text)
         (glimmer_closing_tag)))))
 
 
@@ -52,11 +53,13 @@ const WithSemi = <template>
       (identifier)
       (glimmer_template
         (glimmer_opening_tag)
+        (raw_text)
         (glimmer_closing_tag))))
 
   (expression_statement
     (glimmer_template
       (glimmer_opening_tag)
+      (raw_text)
       (glimmer_closing_tag))))
 
 ============================================
@@ -90,11 +93,13 @@ const WithSemi = <template>
       (identifier)
       (glimmer_template
         (glimmer_opening_tag)
+        (raw_text)
         (glimmer_closing_tag))))
 
   (expression_statement
     (glimmer_template
       (glimmer_opening_tag)
+      (raw_text)
       (glimmer_closing_tag))))
 
 ============================================
@@ -115,6 +120,7 @@ class InClass {
     (class_body
       (glimmer_template
         (glimmer_opening_tag)
+        (raw_text)
         (glimmer_closing_tag)))))
 
 ============================================
@@ -132,5 +138,6 @@ JS Regex Evasion
   (expression_statement
     (glimmer_template
       (glimmer_opening_tag)
+      (raw_text)
       (glimmer_closing_tag)
     )))


### PR DESCRIPTION
To add gts syntax highlighting to Zed, I wasn't able to use `injection.include-children` to inject hbs grammar into the template tag. The pattern of exposing it as raw_text matches Vue and Svelte.

Will/can do the same for tree-sitter-glimmer-javascript if this seems sensible